### PR TITLE
Nye postIds for rammeavtale hørsel 1 mars

### DIFF
--- a/sortiment_av_apostid_per_kategori2.json
+++ b/sortiment_av_apostid_per_kategori2.json
@@ -239,28 +239,19 @@
   ],
   "Hørsels- og varslingshjelpemidler": [
     {
-      "apostid": 1108,
-      "postId": "dfdd22c1-5720-4e78-bc95-7ca4ec12f69e"
+      "postId": "960cf84e-f39c-42dc-97ee-b6652ca2601f"
     },
     {
-      "apostid": 1110,
-      "postId": "49a823e0-0fe1-4a66-a3dd-269cd89d24eb"
+      "postId": "aeb55277-d52b-41bc-9e0c-5f60975ce67b"
     },
     {
-      "apostid": 1112,
-      "postId": "e3fc9c4e-708c-41a9-951e-b6e8df486f9b"
+      "postId": "f42da5df-660f-4aeb-9c40-6c254a7fb467"
     },
     {
-      "apostid": 1113,
-      "postId": "9e1f7851-2fcc-4c85-a784-26ba348eb46c"
+      "postId": "8216cbef-9cce-4584-afc2-38ce0f5c3286"
     },
     {
-      "apostid": 1119,
-      "postId": "51841adf-d88b-4260-a15f-0faea6e57ef7"
-    },
-    {
-      "apostid": 1120,
-      "postId": "e2050f64-dbd7-49db-860d-194b09e1a09c"
+      "postId": "caf454c4-ae10-4dc7-af77-cbed3c66d55c"
     }
   ],
   "Kalendere og planleggingssystemer": [

--- a/sortiment_av_apostid_per_kategori_dev2.json
+++ b/sortiment_av_apostid_per_kategori_dev2.json
@@ -239,28 +239,19 @@
   ],
   "Hørsels- og varslingshjelpemidler": [
     {
-      "apostid": 1108,
-      "postId": "d7acc980-bc19-4231-b947-a660fcb8402c"
+      "postId": "946b62dd-b3e5-4c59-928c-f43e9a0bb21d"
     },
     {
-      "apostid": 1110,
-      "postId": "d8f6379d-4d5c-4ba0-b4dc-dfb8e267c7cb"
+      "postId": "c9900159-d311-4b8a-8610-ddebfa9d589a"
     },
     {
-      "apostid": 1112,
-      "postId": "bb9b5d9a-52ba-421f-af0e-f5fff7561cf2"
+      "postId": "25570081-f81b-4fc3-b74c-8b83b37cedd9"
     },
     {
-      "apostid": 1113,
-      "postId": "88e90a8f-1ffb-43d8-893b-3cce214043d4"
+      "postId": "494d9a54-c1e1-43bb-a394-e93880994dd3"
     },
     {
-      "apostid": 1119,
-      "postId": "1acc197e-ab02-4123-85f5-572c4a4ad138"
-    },
-    {
-      "apostid": 1120,
-      "postId": "603cb681-8b2c-4a71-b69e-09d4c8809108"
+      "postId": "88312a68-4fbd-4ce5-9fe0-24735ef3d125"
     }
   ],
   "Kalendere og planleggingssystemer": [


### PR DESCRIPTION
Fjerner også apostId da disse ikke brukes lenger.